### PR TITLE
Fixed bugs in decode.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,8 +13,8 @@ def main():
         try:
             # Ask for encode parameters
             if choice == "e":
-                path = input("Enter the filename to save to: ")
-                format = input("Enter the file's format (.ext): ")
+                path = input("Enter the filename to save to (include file extension): ")
+                format = input("Enter the file's format (\"mp3\", \"wav\", etc.): ")
                 message = input("Enter the message to encode: ")
                 wpm = input("Enter the wpm to encode at: ")
 
@@ -23,8 +23,8 @@ def main():
                 print("Message successfully encoded!")
             # Ask for decode parameters
             else:
-                path = input("Enter the file's path: ")
-                format = input("Enter the file's format (.ext): ")
+                path = input("Enter the filepath and filename (include file extension): ")
+                format = input("Enter the file's format (\"mp3\", \"wav\", etc.): ")
 
                 dec_instance = Decode(path, format)
                 decoded = dec_instance.decode()
@@ -34,7 +34,7 @@ def main():
         except KeyboardInterrupt:
             quit()
         except Exception as e:
-            print("An error ocurred, please enter valid parameters")
+            print("\nAn error ocurred, please enter valid parameters")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes:
- Properly splits audio into chunks
  - used to read nonexistent pauses at the start of audio
- Sorts the 3 most common keys by length
  - used to exist edge cases where sorting by frequency did not match sorting by length (ex. "A B C DE" read as "I H H 5")
- No longer breaks when not all 3 types of pauses are used
  - used to break with single character messages
  - didn't break as often with single words due to pause being read at start of audio (mentioned above, had to be fixed due to other complications)

Made user prompts for parameters more specific